### PR TITLE
Fixed native PhysicsSoftBody.setPhysicsRotation() incorrectly calling…

### DIFF
--- a/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsSoftBody.cpp
+++ b/jme3-bullet-native/src/native/cpp/com_jme3_bullet_objects_PhysicsSoftBody.cpp
@@ -629,7 +629,7 @@ extern "C" {
             return;
         }
         btMatrix3x3 rot = btMatrix3x3();
-        jmeBulletUtil::convert(env, rotation, &rot);
+        jmeBulletUtil::convertQuat(env, rotation, &rot);
         rot = body->m_initialWorldTransform.inverse().getBasis() * rot;
         btQuaternion quat;
         rot.getRotation(quat);


### PR DESCRIPTION
… jmeBulletUtil::convert() instead of jmeBulletUtil::convertQuat(). convert() expects the jobject to be Matrix3f, not Quaternion.
